### PR TITLE
Unit Testing Refactored Again

### DIFF
--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -6,12 +6,30 @@ function runTests(runTF) {
   if (runTF == true) {
     var passFail = [
     // memory function unit tests
-      new UnitTest('simulateFirstVisit()', function() { return simulateFirstVisit(true); }, '{}'),
-      new UnitTest('checkMemory()', function() { return checkMemory(); }, 'true'),
-      new UnitTest('new SaveItem()', function() { return new SaveItem('test_id', 'test_name', ['test', 'array']).id; }, function() { return JSON.parse(localStorage.saved)['test_id'].id; }),
-      new UnitTest('loadMemory()', function() { return loadMemory().includes("id='delete_test_id'>"); }, true),
-      new UnitTest('deleteSaveItem()', function() { return !('test_id' in deleteSaveItem('test_id', true)); }, true),
-      new UnitTest('restoreDefaultSaveItems()', function() { return restoreDefaultSaveItems()['longsword'].id; }, function() {return JSON.parse(localStorage.saved)['longsword'].id; }),
+      new UnitTest('simulateFirstVisit()', function() {
+          return (simulateFirstVisit(true) === '{}');
+      }),
+      new UnitTest('checkMemory()', function() {
+        return (checkMemory() === "true");
+      }),
+      new UnitTest('new SaveItem()', function() {
+        var saveItem = new SaveItem('test_id', 'test_name', ['test', 'array']);
+        saveItem = JSON.stringify(saveItem);
+        var localSaveItem = localStorage.saved;
+        return (localSaveItem.includes(saveItem));
+      }),
+      new UnitTest('loadMemory()', function() {
+        var savedMenu = loadMemory();
+        return (content.savedMenu.includes(savedMenu));
+      }),
+      new UnitTest('deleteSaveItem()', function() {
+        return !('test_id' in deleteSaveItem('test_id', true));
+      }),
+      new UnitTest('restoreDefaultSaveItems()', function() {
+        var saved = restoreDefaultSaveItems();
+        saved = JSON.stringify(saved);
+        return (saved === localStorage.saved);
+      }),
       // data manipulation tests
 
     ];
@@ -32,11 +50,11 @@ function UnitTest(testName, functionToBeTested) {
       throw 'unexpected result';
     }
     else{
-      this.report = ' passed.'
+      this.report = ' PASS'
     }
   }
   catch(err) {
-    this.report = ' failed:\n' + err;
+    this.report = ' FAIL:\n' + err;
   }
   console.log(this.testName + this.report);
   return this.testName + this.report;

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -46,12 +46,10 @@ function UnitTest(testName, functionToBeTested) {
   this.functionToBeTested = functionToBeTested;
   this.report;
   try {
-    if (functionToBeTested() !== true) {
+    if (!functionToBeTested()) {
       throw 'unexpected result';
     }
-    else{
-      this.report = ' PASS'
-    }
+    this.report = ' PASS';
   }
   catch(err) {
     this.report = ' FAIL:\n' + err;

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -23,24 +23,21 @@ function runTests(runTF) {
   }
 }
 
-function UnitTest(testName, functionToBeTested, expectedOutput) {
-  this.report;
+function UnitTest(testName, functionToBeTested) {
   this.testName = testName;
   this.functionToBeTested = functionToBeTested;
-  this.expectedOutput = expectedOutput;
+  this.report;
   try {
-    this.functionReturned = this.functionToBeTested();
-    if (typeof this.expectedOutput === 'function') { this.expectedOutput = this.expectedOutput(); }
-    if (this.functionReturned != this.expectedOutput) {
-      this.report = '\n\tFailed.\n\tReturned: ' + this.functionReturned + '\n\tExpected: ' + this.expectedOutput;
-      throw this.report;
+    if (functionToBeTested() !== true) {
+      throw 'unexpected result';
+    }
+    else{
+      this.report = ' passed.'
     }
   }
   catch(err) {
-    console.log(this.testName + err);
-    return this.testName + this.report;
+    this.report = ' failed:\n' + err;
   }
-  this.report = '\n\tPassed.\n\tReturned: ' + this.functionReturned;
-  console.log( this.testName + this.report);
+  console.log(this.testName + this.report);
   return this.testName + this.report;
 }


### PR DESCRIPTION
TL;DR:
- REMOVED `UnitTest(expectedOutput)` & `UnitTest.expectedOutput`
- REMOVED comparison between `UnitTest.functionReturned` and `UnitTest.expectedOutput`
- ADDED bool comparison to `UnitTest()`'s `try`/`catch` scenario 
- - `UnitTest.functionReturned` should `return true`, or throw an error
- CONSOLIDATED `returns` and `console.log()`s in `UnitTest()` to the end of the function
- REMOVED `expectedOutput`s from instances of `UnitTest()`
- REFACTORED instances of `UnitTest()` to `return true || false`