### PR TITLE
Add listener unit tests

### DIFF
--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -43,7 +43,11 @@ function Stub() {
     called: {
       count: 0,
       check: function(expectedCount) {
-        return (expectedCount && (expectedCount === info.called.count)) || info.called.count > 0;
+        if (expectedCount) {
+          return (expectedCount === info.called.count)
+        } else {
+          return info.called.count > 0;
+        }
       }
     },
     args: {
@@ -148,6 +152,7 @@ function testList() {
       return true;
     }),
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
+      // assert(app.contex.attach.info.called.check)
       // return true;
     }),
     new UnitTest('addRollBarListeners()', function(app, test) {

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -75,16 +75,23 @@ function Stub() {
     },
   }
 
-  var placeHolder = function() {
-    info.called.true = true;
+  var functionStub = function() {
     info.args.current = arguments;
     info.args.log(info.args.current);
     info.called.count++;
     return true;
   }
+  var bindStub = function() {
+    bindStub.info.args.current = arguments;
+    bindStub.info.args.log(bindStub.info.args.current);
+    bindStub.info.called.count++;
+    return true;
+  }
 
-  placeHolder.info = info;
-  return placeHolder;
+  functionStub.info = info;
+  bindStub.info = info;
+  functionStub.bind = bindStub;
+  return functionStub;
 }
 
 function testList() {
@@ -120,43 +127,107 @@ function testList() {
     new UnitTest('addNumberKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress = new Stub();
+
       app.addNumberKeyListeners();
+
+      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
+      assert(app.keypadPress.bind.info.called.check(10), 'keypadPress.bind() not called 10 times');
+      assert(app.keypadPress.bind.info.args.all.check(0, app, 0), 'keypadPress.bind() num0 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(1, app, 1), 'keypadPress.bind() num1 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(2, app, 2), 'keypadPress.bind() num2 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(3, app, 3), 'keypadPress.bind() num3 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(4, app, 4), 'keypadPress.bind() num4 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(5, app, 5), 'keypadPress.bind() num5 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(6, app, 6), 'keypadPress.bind() num6 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(7, app, 7), 'keypadPress.bind() num7 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(8, app, 8), 'keypadPress.bind() num8 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(9, app, 9), 'keypadPress.bind() num9 unexpected arguments');
+
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(10), 'context.attach() not called 10 times');
-      assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(this, 0)), 'attach() num0 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'num1', 'click', app.keypadPress.bind(this, 1)), 'attach() num1 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(2, 'num2', 'click', app.keypadPress.bind(this, 2)), 'attach() num2 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(3, 'num3', 'click', app.keypadPress.bind(this, 3)), 'attach() num3 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(4, 'num4', 'click', app.keypadPress.bind(this, 4)), 'attach() num4 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(5, 'num5', 'click', app.keypadPress.bind(this, 5)), 'attach() num5 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(6, 'num6', 'click', app.keypadPress.bind(this, 6)), 'attach() num6 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(7, 'num7', 'click', app.keypadPress.bind(this, 7)), 'attach() num7 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(8, 'num8', 'click', app.keypadPress.bind(this, 8)), 'attach() num8 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(9, 'num9', 'click', app.keypadPress.bind(this, 9)), 'attach() num9 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(app, 0)), 'context.attach() num0 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(1, 'num1', 'click', app.keypadPress.bind(app, 1)), 'context.attach() num1 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(2, 'num2', 'click', app.keypadPress.bind(app, 2)), 'context.attach() num2 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(3, 'num3', 'click', app.keypadPress.bind(app, 3)), 'context.attach() num3 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(4, 'num4', 'click', app.keypadPress.bind(app, 4)), 'context.attach() num4 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(5, 'num5', 'click', app.keypadPress.bind(app, 5)), 'context.attach() num5 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(6, 'num6', 'click', app.keypadPress.bind(app, 6)), 'context.attach() num6 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(7, 'num7', 'click', app.keypadPress.bind(app, 7)), 'context.attach() num7 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(8, 'num8', 'click', app.keypadPress.bind(app, 8)), 'context.attach() num8 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(9, 'num9', 'click', app.keypadPress.bind(app, 9)), 'context.attach() num9 unexpected arguments');
       return true;
     }),
     new UnitTest('addDiceKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress = new Stub();
+
       app.addDiceKeyListeners();
+
+      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
+      assert(app.keypadPress.bind.info.called.check(8), 'keypadPress.bind() not called 8 times');
+      assert(app.keypadPress.bind.info.args.all.check(0, app, 'd100'), 'keypadPress.bind() d100 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(1, app, 'd20'), 'keypadPress.bind() d20 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(2, app, 'd12'), 'keypadPress.bind() d12 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(3, app, 'd10'), 'keypadPress.bind() d10 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(4, app, 'd8'), 'keypadPress.bind() d8 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(5, app, 'd6'), 'keypadPress.bind() d6 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(6, app, 'd4'), 'keypadPress.bind() d4 unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(7, app, 'd2'), 'keypadPress.bind() d2 unexpected arguments');
+
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(8), 'context.attach() not called 8 times');
-      assert(app.context.attach.info.args.all.check(0, 'd100', 'click', app.keypadPress.bind(this, 'd100')), 'attach() d100 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(1, 'd20', 'click', app.keypadPress.bind(this, 'd20')), 'attach() d20 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(2, 'd12', 'click', app.keypadPress.bind(this, 'd12')), 'attach() d12 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(3, 'd10', 'click', app.keypadPress.bind(this, 'd10')), 'attach() d10 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(4, 'd8', 'click', app.keypadPress.bind(this, 'd8')), 'attach() d8 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(5, 'd6', 'click', app.keypadPress.bind(this, 'd6')), 'attach() d6 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(6, 'd4', 'click', app.keypadPress.bind(this, 'd4')), 'attach() d4 unexpected arguments')
-      assert(app.context.attach.info.args.all.check(7, 'd2', 'click', app.keypadPress.bind(this, 'd2')), 'attach() d2 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(0, 'd100', 'click', app.keypadPress.bind(app, 'd100')), 'context.attach() d100 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(1, 'd20', 'click', app.keypadPress.bind(app, 'd20')), 'context.attach() d20 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(2, 'd12', 'click', app.keypadPress.bind(app, 'd12')), 'context.attach() d12 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(3, 'd10', 'click', app.keypadPress.bind(app, 'd10')), 'context.attach() d10 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(4, 'd8', 'click', app.keypadPress.bind(app, 'd8')), 'context.attach() d8 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(5, 'd6', 'click', app.keypadPress.bind(app, 'd6')), 'context.attach() d6 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(6, 'd4', 'click', app.keypadPress.bind(app, 'd4')), 'context.attach() d4 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(7, 'd2', 'click', app.keypadPress.bind(app, 'd2')), 'context.attach() d2 unexpected arguments');
       return true;
     }),
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
-      // assert(app.contex.attach.info.called.check)
-      // return true;
+      app.context.attach = new Stub();
+      app.keypadPress = new Stub();
+
+      app.addOperatorKeyListeners();
+
+      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
+      assert(app.keypadPress.bind.info.called.check(2), 'keypadPress.bind() not called twice');
+      assert(app.keypadPress.bind.info.args.all.check(0, app, '+'), 'keypadPress.bind() num+ unexpected arguments');
+      assert(app.keypadPress.bind.info.args.all.check(1, app, '-'), 'keypadPress.bind() num- unexpected arguments');
+
+      assert(app.context.attach.info.called.check(), 'context.attach() not called');
+      assert(app.context.attach.info.called.check(2), 'context.attach() not called twice');
+      assert(app.context.attach.info.args.all.check(0, 'num+', 'click', app.keypadPress.bind(app, '+')), 'context.attach() num+ unexpected arguments');
+      assert(app.context.attach.info.args.all.check(1, 'num-', 'click', app.keypadPress.bind(app, '-')), 'context.attach() num- unexpected arguments');
+
+      return true;
     }),
     new UnitTest('addRollBarListeners()', function(app, test) {
-      // return true;
+      app.context.attach = new Stub();
+      app.clearDisplay = new Stub();
+      app.rollPress = new Stub();
+      app.toggleMenu = new Stub();
+
+      app.addRollBarListeners();
+
+      assert(app.clearDisplay.bind.info.called.check(), 'clearDisplay.bind() not called');
+      assert(app.clearDisplay.bind.info.args.all.check(0, app), 'clearDisplay.bind() unexpected arguments');
+
+      assert(app.rollPress.bind.info.called.check(), 'rollPress.bind() not called');
+      assert(app.rollPress.bind.info.args.all.check(0, app), 'rollPress.bind() unexpected arguments');
+
+      assert(app.toggleMenu.bind.info.called.check(), 'toggleMenu.bind() not called');
+      assert(app.toggleMenu.bind.info.args.all.check(0, app), 'toggleMenu.bind() unexpected arguments');
+
+      assert(app.context.attach.info.called.check(), 'context.attach() not called');
+      assert(app.context.attach.info.called.check(3), 'context.attach() not called twice');
+      assert(app.context.attach.info.args.all.check(0, 'clrBtn',  'click', app.clearDisplay.bind(app)), 'context.attach() clrBtn unexpected arguments');
+      assert(app.context.attach.info.args.all.check(1, 'rollBtn',  'click', app.rollPress.bind(app)), 'context.attach() rollBtn unexpected arguments');
+      assert(app.context.attach.info.args.all.check(2, 'toggleMenuBtn',  'click', app.toggleMenu.bind(app)), 'context.attach() toggleMenuBtn unexpected arguments');
+
+      return true;
     }),
     new UnitTest('addUserSaveButtonListener()', function(app, test) {
       // return true;

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -38,7 +38,7 @@ function assert(condition, message) {
   }
 }
 
-function Stub() {
+function Stub(output) {
   var info = {
     called: {
       count: 0,
@@ -79,13 +79,13 @@ function Stub() {
     info.args.current = arguments;
     info.args.log(info.args.current);
     info.called.count++;
-    return true;
+    return output;
   }
   var bindStub = function() {
     bindStub.info.args.current = arguments;
     bindStub.info.args.log(bindStub.info.args.current);
     bindStub.info.called.count++;
-    return true;
+    return arguments;
   }
 
   functionStub.info = info;
@@ -127,9 +127,7 @@ function testList() {
     new UnitTest('addNumberKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress = new Stub();
-
       app.addNumberKeyListeners();
-
       assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
       assert(app.keypadPress.bind.info.called.check(10), 'keypadPress.bind() not called 10 times');
       assert(app.keypadPress.bind.info.args.all.check(0, app, 0), 'keypadPress.bind() num0 unexpected arguments');
@@ -142,7 +140,6 @@ function testList() {
       assert(app.keypadPress.bind.info.args.all.check(7, app, 7), 'keypadPress.bind() num7 unexpected arguments');
       assert(app.keypadPress.bind.info.args.all.check(8, app, 8), 'keypadPress.bind() num8 unexpected arguments');
       assert(app.keypadPress.bind.info.args.all.check(9, app, 9), 'keypadPress.bind() num9 unexpected arguments');
-
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(10), 'context.attach() not called 10 times');
       assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(app, 0)), 'context.attach() num0 unexpected arguments');
@@ -160,9 +157,7 @@ function testList() {
     new UnitTest('addDiceKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress = new Stub();
-
       app.addDiceKeyListeners();
-
       assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
       assert(app.keypadPress.bind.info.called.check(8), 'keypadPress.bind() not called 8 times');
       assert(app.keypadPress.bind.info.args.all.check(0, app, 'd100'), 'keypadPress.bind() d100 unexpected arguments');
@@ -173,7 +168,6 @@ function testList() {
       assert(app.keypadPress.bind.info.args.all.check(5, app, 'd6'), 'keypadPress.bind() d6 unexpected arguments');
       assert(app.keypadPress.bind.info.args.all.check(6, app, 'd4'), 'keypadPress.bind() d4 unexpected arguments');
       assert(app.keypadPress.bind.info.args.all.check(7, app, 'd2'), 'keypadPress.bind() d2 unexpected arguments');
-
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(8), 'context.attach() not called 8 times');
       assert(app.context.attach.info.args.all.check(0, 'd100', 'click', app.keypadPress.bind(app, 'd100')), 'context.attach() d100 unexpected arguments');
@@ -189,19 +183,15 @@ function testList() {
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress = new Stub();
-
       app.addOperatorKeyListeners();
-
       assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
       assert(app.keypadPress.bind.info.called.check(2), 'keypadPress.bind() not called twice');
       assert(app.keypadPress.bind.info.args.all.check(0, app, '+'), 'keypadPress.bind() num+ unexpected arguments');
       assert(app.keypadPress.bind.info.args.all.check(1, app, '-'), 'keypadPress.bind() num- unexpected arguments');
-
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(2), 'context.attach() not called twice');
       assert(app.context.attach.info.args.all.check(0, 'num+', 'click', app.keypadPress.bind(app, '+')), 'context.attach() num+ unexpected arguments');
       assert(app.context.attach.info.args.all.check(1, 'num-', 'click', app.keypadPress.bind(app, '-')), 'context.attach() num- unexpected arguments');
-
       return true;
     }),
     new UnitTest('addRollBarListeners()', function(app, test) {
@@ -209,28 +199,50 @@ function testList() {
       app.clearDisplay = new Stub();
       app.rollPress = new Stub();
       app.toggleMenu = new Stub();
-
       app.addRollBarListeners();
-
       assert(app.clearDisplay.bind.info.called.check(), 'clearDisplay.bind() not called');
       assert(app.clearDisplay.bind.info.args.all.check(0, app), 'clearDisplay.bind() unexpected arguments');
-
       assert(app.rollPress.bind.info.called.check(), 'rollPress.bind() not called');
       assert(app.rollPress.bind.info.args.all.check(0, app), 'rollPress.bind() unexpected arguments');
-
       assert(app.toggleMenu.bind.info.called.check(), 'toggleMenu.bind() not called');
       assert(app.toggleMenu.bind.info.args.all.check(0, app), 'toggleMenu.bind() unexpected arguments');
-
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(3), 'context.attach() not called twice');
       assert(app.context.attach.info.args.all.check(0, 'clrBtn',  'click', app.clearDisplay.bind(app)), 'context.attach() clrBtn unexpected arguments');
       assert(app.context.attach.info.args.all.check(1, 'rollBtn',  'click', app.rollPress.bind(app)), 'context.attach() rollBtn unexpected arguments');
       assert(app.context.attach.info.args.all.check(2, 'toggleMenuBtn',  'click', app.toggleMenu.bind(app)), 'context.attach() toggleMenuBtn unexpected arguments');
-
       return true;
     }),
     new UnitTest('addUserSaveButtonListener()', function(app, test) {
-      // return true;
+      app.context.attach = new Stub();
+      app.userSaveButtonPress = new Stub();
+      app.addUserSaveButtonListener();
+      assert(app.userSaveButtonPress.bind.info.called.check(), 'userSaveButtonPress.bind() not called');
+      assert(app.userSaveButtonPress.bind.info.args.check(app), 'userSaveButtonPress.bind() unexpected arguments');
+      assert(app.context.attach.info.called.check(), 'context.attach() not called');
+      assert(app.context.attach.info.args.check('userSaveButton', 'click', app.userSaveButtonPress.bind(app)), 'context.attach() unexpected arguments');
+      return true;
+    }),
+    new UnitTest('addSaveItemListeners()', function(app, test) {
+      app.context.attach = new Stub();
+      app.saveItemPress = new Stub();
+      app.comingSoon = new Stub();
+      app.deleteSaveItem = new Stub();
+      var id = 'id';
+      var rollArray = ['rollArray'];
+      app.addSaveItemListeners('id', rollArray);
+      assert(app.saveItemPress.bind.info.called.check(), 'saveItemPress.bind() not called');
+      assert(app.saveItemPress.bind.info.args.check(app, id, rollArray), 'saveItemPress.bind() unexpected arguments');
+      assert(app.comingSoon.bind.info.called.check(), 'comingSoon.bind() not called');
+      assert(app.comingSoon.bind.info.args.check(app), 'comingSoon.bind() unexpected arguments');
+      assert(app.deleteSaveItem.bind.info.called.check(), 'deleteSaveItem.bind() not called');
+      assert(app.deleteSaveItem.bind.info.args.check(app, id), 'deleteSaveItem.bind() unexpected arguments');
+      assert(app.context.attach.info.called.check(), 'context.attach() not called');
+      assert(app.context.attach.info.called.check(3), 'context.attach() not called 3 times');
+      assert(app.context.attach.info.args.all.check(0, id, 'click', app.saveItemPress.bind(app, id, rollArray)), 'context.attach() saveItemPress unexpected args');
+      assert(app.context.attach.info.args.all.check(1, 'mod_' + id, 'click', app.comingSoon.bind(app)), 'context.attach() mod_id unexpected args');
+      assert(app.context.attach.info.args.all.check(2, 'delete_' + id, 'click', app.deleteSaveItem.bind(app, id)), 'context.attach() delete_id unexpected args');
+      return true;
     }),
   ];
 }

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -38,7 +38,7 @@ function assert(condition, message) {
   }
 }
 
-function stub() {
+function Stub() {
   var info = {
     called: {
       count: 0,
@@ -86,13 +86,13 @@ function stub() {
 function testList() {
   return [
     new UnitTest('run()', function(app, test) {
-      app.addRollBarListeners = stub();
-      app.addCalculatorListeners = stub();
-      app.addUserSaveButtonListener = stub();
-      app.simulateFirstVisit = stub();
-      app.checkMemory = stub();
-      app.toggleMenu = stub();
-      app.userSaveButtonCheckDisplay = stub();
+      app.addRollBarListeners = new Stub();
+      app.addCalculatorListeners = new Stub();
+      app.addUserSaveButtonListener = new Stub();
+      app.simulateFirstVisit = new Stub();
+      app.checkMemory = new Stub();
+      app.toggleMenu = new Stub();
+      app.userSaveButtonCheckDisplay = new Stub();
       app.run();
       assert(app.addRollBarListeners.info.called.check(), 'addRollBarListeners() not called');
       assert(app.addCalculatorListeners.info.called.check(), 'addCalculatorListeners() not called');
@@ -104,9 +104,9 @@ function testList() {
       return true;
     }),
     new UnitTest('addCalculatorListeners()', function(app, test) {
-      app.addNumberKeyListeners = stub();
-      app.addDiceKeyListeners = stub();
-      app.addOperatorKeyListeners = stub();
+      app.addNumberKeyListeners = new Stub();
+      app.addDiceKeyListeners = new Stub();
+      app.addOperatorKeyListeners = new Stub();
       app.addCalculatorListeners();
       assert(app.addNumberKeyListeners.info.called.check(), 'addNumberKeyListeners() not called');
       assert(app.addDiceKeyListeners.info.called.check(), 'addDiceKeyListeners() not called');
@@ -114,25 +114,38 @@ function testList() {
       return true;
     }),
     new UnitTest('addNumberKeyListeners()', function(app, test) {
-      app.context.attach = stub();
-      app.keypadPress = stub();
+      app.context.attach = new Stub();
+      app.keypadPress = new Stub();
       app.addNumberKeyListeners();
       assert(app.context.attach.info.called.check(), 'context.attach() not called');
       assert(app.context.attach.info.called.check(10), 'context.attach() not called 10 times');
-      assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(this, 0)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'num1', 'click', app.keypadPress.bind(this, 1)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(2, 'num2', 'click', app.keypadPress.bind(this, 2)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(3, 'num3', 'click', app.keypadPress.bind(this, 3)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(4, 'num4', 'click', app.keypadPress.bind(this, 4)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(5, 'num5', 'click', app.keypadPress.bind(this, 5)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(6, 'num6', 'click', app.keypadPress.bind(this, 6)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(7, 'num7', 'click', app.keypadPress.bind(this, 7)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(8, 'num8', 'click', app.keypadPress.bind(this, 8)), 'attach() unexpected arguments');
-      assert(app.context.attach.info.args.all.check(9, 'num9', 'click', app.keypadPress.bind(this, 9)), 'attach() unexpected arguments');
+      assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(this, 0)), 'attach() num0 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(1, 'num1', 'click', app.keypadPress.bind(this, 1)), 'attach() num1 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(2, 'num2', 'click', app.keypadPress.bind(this, 2)), 'attach() num2 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(3, 'num3', 'click', app.keypadPress.bind(this, 3)), 'attach() num3 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(4, 'num4', 'click', app.keypadPress.bind(this, 4)), 'attach() num4 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(5, 'num5', 'click', app.keypadPress.bind(this, 5)), 'attach() num5 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(6, 'num6', 'click', app.keypadPress.bind(this, 6)), 'attach() num6 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(7, 'num7', 'click', app.keypadPress.bind(this, 7)), 'attach() num7 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(8, 'num8', 'click', app.keypadPress.bind(this, 8)), 'attach() num8 unexpected arguments');
+      assert(app.context.attach.info.args.all.check(9, 'num9', 'click', app.keypadPress.bind(this, 9)), 'attach() num9 unexpected arguments');
       return true;
     }),
     new UnitTest('addDiceKeyListeners()', function(app, test) {
-      // return true;
+      app.context.attach = new Stub();
+      app.keypadPress = new Stub();
+      app.addDiceKeyListeners();
+      assert(app.context.attach.info.called.check(), 'context.attach() not called');
+      assert(app.context.attach.info.called.check(8), 'context.attach() not called 8 times');
+      assert(app.context.attach.info.args.all.check(0, 'd100', 'click', app.keypadPress.bind(this, 'd100')), 'attach() d100 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(1, 'd20', 'click', app.keypadPress.bind(this, 'd20')), 'attach() d20 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(2, 'd12', 'click', app.keypadPress.bind(this, 'd12')), 'attach() d12 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(3, 'd10', 'click', app.keypadPress.bind(this, 'd10')), 'attach() d10 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(4, 'd8', 'click', app.keypadPress.bind(this, 'd8')), 'attach() d8 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(5, 'd6', 'click', app.keypadPress.bind(this, 'd6')), 'attach() d6 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(6, 'd4', 'click', app.keypadPress.bind(this, 'd4')), 'attach() d4 unexpected arguments')
+      assert(app.context.attach.info.args.all.check(7, 'd2', 'click', app.keypadPress.bind(this, 'd2')), 'attach() d2 unexpected arguments')
+      return true;
     }),
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
       // return true;

--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -25,72 +25,65 @@ function UnitTest(testName, testFunction) {
   };
 }
 
-function assert(condition, message) {
-  if (!condition) {
-    message = message || 'Assertion failed';
-    if (typeof Error !== 'undefined') {
-      var err = Error.name + ': ' + message;
-      throw err;
+var assert = {
+  ok: function(condition, message) {
+    if (!condition) {
+      message = message || 'Assertion failed';
+      if (typeof Error !== 'undefined') {
+        var err = Error.name + ': ' + message;
+        throw err;
+      }
+      throw message;
+    } else {
+      return 'Assertion passed';
     }
-    throw message;
-  } else {
-    return 'Assertion passed';
-  }
+  },
+  compare: function(storedResult, expectedResult, message) {
+    if (storedResult !== expectedResult) {
+      message = message || 'Assertion failed';
+      if (typeof Error !== 'undefined') {
+        var err = Error.name + ': ' + message;
+        throw err;
+      }
+      throw message;
+    } else {
+      return 'Assertion passed';
+    }
+  },
+  compareArgs: function(storedResult, expectedResult, message) {
+    storedResult = JSON.stringify(Array.from(storedResult));
+    expectedResult = JSON.stringify(Array.from(expectedResult));
+    if (storedResult !== expectedResult) {
+      message = message || 'Assertion failed';
+      if (typeof Error !== 'undefined') {
+        var err = Error.name + ': ' + message;
+        throw err;
+      }
+      throw message;
+    } else {
+      return 'Assertion passed';
+    }
+  },
 }
 
 function Stub(output) {
   var info = {
-    called: {
-      count: 0,
-      check: function(expectedCount) {
-        if (expectedCount) {
-          return (expectedCount === info.called.count)
-        } else {
-          return info.called.count > 0;
-        }
-      }
-    },
+    output: output,
+    called: 0,
     args: {
-      current: null,
-      all: {
-        array: [],
-        check: function(index, expectedArguments) {
-          var index = arguments[0];
-          var expected = {};
-          for (key in arguments) {
-            if (key !== "0") {
-              expected[key - 1] = arguments[key];
-            }
-          }
-          return (JSON.stringify(expected) === JSON.stringify(info.args.all.array[index]));
-        }
-      },
+      all: [],
       log: function(current) {
-        info.args.all.array[info.called.count] = current;
+        info.args.all[info.called] = current;
       },
-      check: function(expectedArgs) {
-        var expected = arguments;
-        return (JSON.stringify(expected) === JSON.stringify(info.args.current));
-      }
     },
   }
 
   var functionStub = function() {
-    info.args.current = arguments;
-    info.args.log(info.args.current);
-    info.called.count++;
-    return output;
+    info.args.log(arguments);
+    info.called++;
+    return info.output;
   }
-  var bindStub = function() {
-    bindStub.info.args.current = arguments;
-    bindStub.info.args.log(bindStub.info.args.current);
-    bindStub.info.called.count++;
-    return arguments;
-  }
-
   functionStub.info = info;
-  bindStub.info = info;
-  functionStub.bind = bindStub;
   return functionStub;
 }
 
@@ -105,13 +98,13 @@ function testList() {
       app.toggleMenu = new Stub();
       app.userSaveButtonCheckDisplay = new Stub();
       app.run();
-      assert(app.addRollBarListeners.info.called.check(), 'addRollBarListeners() not called');
-      assert(app.addCalculatorListeners.info.called.check(), 'addCalculatorListeners() not called');
-      assert(app.addUserSaveButtonListener.info.called.check(), 'addUserSaveButtonListener() not called');
-      assert(app.simulateFirstVisit.info.called.check(), 'simulateFirstVisit() not called');
-      assert(app.checkMemory.info.called.check(), 'checkMemory() not called');
-      assert(app.toggleMenu.info.called.check(), 'toggleMenu() not called');
-      assert(app.userSaveButtonCheckDisplay.info.called.check(), 'userSaveButtonCheckDisplay() not called');
+      assert.compare(app.addRollBarListeners.info.called, 1, 'addRollBarListeners() not called');
+      assert.compare(app.addCalculatorListeners.info.called, 1, 'addCalculatorListeners() not called');
+      assert.compare(app.addUserSaveButtonListener.info.called, 1, 'addUserSaveButtonListener() not called');
+      assert.compare(app.simulateFirstVisit.info.called, 1, 'simulateFirstVisit() not called');
+      assert.compare(app.checkMemory.info.called, 1, 'checkMemory() not called');
+      assert.compare(app.toggleMenu.info.called, 1, 'toggleMenu() not called');
+      assert.compare(app.userSaveButtonCheckDisplay.info.called, 1, 'userSaveButtonCheckDisplay() not called');
       return true;
     }),
     new UnitTest('addCalculatorListeners()', function(app, test) {
@@ -119,129 +112,121 @@ function testList() {
       app.addDiceKeyListeners = new Stub();
       app.addOperatorKeyListeners = new Stub();
       app.addCalculatorListeners();
-      assert(app.addNumberKeyListeners.info.called.check(), 'addNumberKeyListeners() not called');
-      assert(app.addDiceKeyListeners.info.called.check(), 'addDiceKeyListeners() not called');
-      assert(app.addOperatorKeyListeners.info.called.check(), 'addOperatorKeyListeners() not called');
+      assert.compare(app.addNumberKeyListeners.info.called, 1, 'addNumberKeyListeners() not called');
+      assert.compare(app.addDiceKeyListeners.info.called, 1, 'addDiceKeyListeners() not called');
+      assert.compare(app.addOperatorKeyListeners.info.called, 1, 'addOperatorKeyListeners() not called');
       return true;
     }),
     new UnitTest('addNumberKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
-      app.keypadPress = new Stub();
+      app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addNumberKeyListeners();
-      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
-      assert(app.keypadPress.bind.info.called.check(10), 'keypadPress.bind() not called 10 times');
-      assert(app.keypadPress.bind.info.args.all.check(0, app, 0), 'keypadPress.bind() num0 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(1, app, 1), 'keypadPress.bind() num1 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(2, app, 2), 'keypadPress.bind() num2 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(3, app, 3), 'keypadPress.bind() num3 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(4, app, 4), 'keypadPress.bind() num4 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(5, app, 5), 'keypadPress.bind() num5 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(6, app, 6), 'keypadPress.bind() num6 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(7, app, 7), 'keypadPress.bind() num7 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(8, app, 8), 'keypadPress.bind() num8 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(9, app, 9), 'keypadPress.bind() num9 unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.called.check(10), 'context.attach() not called 10 times');
-      assert(app.context.attach.info.args.all.check(0, 'num0', 'click', app.keypadPress.bind(app, 0)), 'context.attach() num0 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'num1', 'click', app.keypadPress.bind(app, 1)), 'context.attach() num1 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(2, 'num2', 'click', app.keypadPress.bind(app, 2)), 'context.attach() num2 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(3, 'num3', 'click', app.keypadPress.bind(app, 3)), 'context.attach() num3 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(4, 'num4', 'click', app.keypadPress.bind(app, 4)), 'context.attach() num4 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(5, 'num5', 'click', app.keypadPress.bind(app, 5)), 'context.attach() num5 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(6, 'num6', 'click', app.keypadPress.bind(app, 6)), 'context.attach() num6 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(7, 'num7', 'click', app.keypadPress.bind(app, 7)), 'context.attach() num7 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(8, 'num8', 'click', app.keypadPress.bind(app, 8)), 'context.attach() num8 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(9, 'num9', 'click', app.keypadPress.bind(app, 9)), 'context.attach() num9 unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.called, 10, 'keypadPress.bind() not called 10 times');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, 0], 'keypadPress.bind() num0 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, 1], 'keypadPress.bind() num1 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[2], [app, 2], 'keypadPress.bind() num2 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[3], [app, 3], 'keypadPress.bind() num3 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[4], [app, 4], 'keypadPress.bind() num4 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[5], [app, 5], 'keypadPress.bind() num5 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[6], [app, 6], 'keypadPress.bind() num6 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[7], [app, 7], 'keypadPress.bind() num7 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[8], [app, 8], 'keypadPress.bind() num8 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[9], [app, 9], 'keypadPress.bind() num9 unexpected arguments');
+      assert.compare(app.context.attach.info.called, 10, 'context.attach() not called 10 times');
+      assert.compareArgs(app.context.attach.info.args.all[0], ['num0', 'click', 'app.keypadPress.bind()'], 'context.attach() num0 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[1], ['num1', 'click', 'app.keypadPress.bind()'], 'context.attach() num1 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[2], ['num2', 'click', 'app.keypadPress.bind()'], 'context.attach() num2 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[3], ['num3', 'click', 'app.keypadPress.bind()'], 'context.attach() num3 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[4], ['num4', 'click', 'app.keypadPress.bind()'], 'context.attach() num4 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[5], ['num5', 'click', 'app.keypadPress.bind()'], 'context.attach() num5 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[6], ['num6', 'click', 'app.keypadPress.bind()'], 'context.attach() num6 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[7], ['num7', 'click', 'app.keypadPress.bind()'], 'context.attach() num7 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[8], ['num8', 'click', 'app.keypadPress.bind()'], 'context.attach() num8 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[9], ['num9', 'click', 'app.keypadPress.bind()'], 'context.attach() num9 unexpected arguments');
       return true;
     }),
     new UnitTest('addDiceKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
-      app.keypadPress = new Stub();
+      app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addDiceKeyListeners();
-      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
-      assert(app.keypadPress.bind.info.called.check(8), 'keypadPress.bind() not called 8 times');
-      assert(app.keypadPress.bind.info.args.all.check(0, app, 'd100'), 'keypadPress.bind() d100 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(1, app, 'd20'), 'keypadPress.bind() d20 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(2, app, 'd12'), 'keypadPress.bind() d12 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(3, app, 'd10'), 'keypadPress.bind() d10 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(4, app, 'd8'), 'keypadPress.bind() d8 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(5, app, 'd6'), 'keypadPress.bind() d6 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(6, app, 'd4'), 'keypadPress.bind() d4 unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(7, app, 'd2'), 'keypadPress.bind() d2 unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.called.check(8), 'context.attach() not called 8 times');
-      assert(app.context.attach.info.args.all.check(0, 'd100', 'click', app.keypadPress.bind(app, 'd100')), 'context.attach() d100 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'd20', 'click', app.keypadPress.bind(app, 'd20')), 'context.attach() d20 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(2, 'd12', 'click', app.keypadPress.bind(app, 'd12')), 'context.attach() d12 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(3, 'd10', 'click', app.keypadPress.bind(app, 'd10')), 'context.attach() d10 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(4, 'd8', 'click', app.keypadPress.bind(app, 'd8')), 'context.attach() d8 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(5, 'd6', 'click', app.keypadPress.bind(app, 'd6')), 'context.attach() d6 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(6, 'd4', 'click', app.keypadPress.bind(app, 'd4')), 'context.attach() d4 unexpected arguments');
-      assert(app.context.attach.info.args.all.check(7, 'd2', 'click', app.keypadPress.bind(app, 'd2')), 'context.attach() d2 unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.called, 8, 'keypadPress.bind() not called 8 times');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, 'd100'], 'keypadPress.bind() d100 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, 'd20'], 'keypadPress.bind() d20 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[2], [app, 'd12'], 'keypadPress.bind() d12 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[3], [app, 'd10'], 'keypadPress.bind() d10 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[4], [app, 'd8'], 'keypadPress.bind() d8 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[5], [app, 'd6'], 'keypadPress.bind() d6 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[6], [app, 'd4'], 'keypadPress.bind() d4 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[7], [app, 'd2'], 'keypadPress.bind() d2 unexpected arguments');
+      assert.compare(app.context.attach.info.called, 8, 'context.attach() not called 8 times');
+      assert.compareArgs(app.context.attach.info.args.all[0], ['d100', 'click', 'app.keypadPress.bind()'], 'context.attach() d100 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[1], ['d20', 'click', 'app.keypadPress.bind()'], 'context.attach() d20 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[2], ['d12', 'click', 'app.keypadPress.bind()'], 'context.attach() d12 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[3], ['d10', 'click', 'app.keypadPress.bind()'], 'context.attach() d10 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[4], ['d8', 'click', 'app.keypadPress.bind()'], 'context.attach() d8 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[5], ['d6', 'click', 'app.keypadPress.bind()'], 'context.attach() d6 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[6], ['d4', 'click', 'app.keypadPress.bind()'], 'context.attach() d4 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[7], ['d2', 'click', 'app.keypadPress.bind()'], 'context.attach() d2 unexpected arguments');
       return true;
     }),
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
-      app.keypadPress = new Stub();
+      app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addOperatorKeyListeners();
-      assert(app.keypadPress.bind.info.called.check(), 'keypadPress.bind() not called');
-      assert(app.keypadPress.bind.info.called.check(2), 'keypadPress.bind() not called twice');
-      assert(app.keypadPress.bind.info.args.all.check(0, app, '+'), 'keypadPress.bind() num+ unexpected arguments');
-      assert(app.keypadPress.bind.info.args.all.check(1, app, '-'), 'keypadPress.bind() num- unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.called.check(2), 'context.attach() not called twice');
-      assert(app.context.attach.info.args.all.check(0, 'num+', 'click', app.keypadPress.bind(app, '+')), 'context.attach() num+ unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'num-', 'click', app.keypadPress.bind(app, '-')), 'context.attach() num- unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.called, 2, 'keypadPress.bind() not called twice');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, '+'], 'keypadPress.bind() num+ unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, '-'], 'keypadPress.bind() num- unexpected arguments');
+      assert.compare(app.context.attach.info.called, 2, 'context.attach() not called twice');
+      assert.compareArgs(app.context.attach.info.args.all[0], ['num+', 'click', 'app.keypadPress.bind()'], 'context.attach() num+ unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[1], ['num-', 'click', 'app.keypadPress.bind()'], 'context.attach() num- unexpected arguments');
       return true;
     }),
     new UnitTest('addRollBarListeners()', function(app, test) {
       app.context.attach = new Stub();
-      app.clearDisplay = new Stub();
-      app.rollPress = new Stub();
-      app.toggleMenu = new Stub();
+      app.clearDisplay.bind = new Stub('app.clearDisplay.bind()');
+      app.rollPress.bind = new Stub('app.rollPress.bind()');
+      app.toggleMenu.bind = new Stub('app.toggleMenu.bind()');
       app.addRollBarListeners();
-      assert(app.clearDisplay.bind.info.called.check(), 'clearDisplay.bind() not called');
-      assert(app.clearDisplay.bind.info.args.all.check(0, app), 'clearDisplay.bind() unexpected arguments');
-      assert(app.rollPress.bind.info.called.check(), 'rollPress.bind() not called');
-      assert(app.rollPress.bind.info.args.all.check(0, app), 'rollPress.bind() unexpected arguments');
-      assert(app.toggleMenu.bind.info.called.check(), 'toggleMenu.bind() not called');
-      assert(app.toggleMenu.bind.info.args.all.check(0, app), 'toggleMenu.bind() unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.called.check(3), 'context.attach() not called twice');
-      assert(app.context.attach.info.args.all.check(0, 'clrBtn',  'click', app.clearDisplay.bind(app)), 'context.attach() clrBtn unexpected arguments');
-      assert(app.context.attach.info.args.all.check(1, 'rollBtn',  'click', app.rollPress.bind(app)), 'context.attach() rollBtn unexpected arguments');
-      assert(app.context.attach.info.args.all.check(2, 'toggleMenuBtn',  'click', app.toggleMenu.bind(app)), 'context.attach() toggleMenuBtn unexpected arguments');
+      assert.compare(app.clearDisplay.bind.info.called, 1, 'clearDisplay.bind() not called');
+      assert.compareArgs(app.clearDisplay.bind.info.args.all[0], [app], 'clearDisplay.bind() unexpected arguments');
+      assert.compare(app.rollPress.bind.info.called, 1, 'rollPress.bind() not called');
+      assert.compareArgs(app.rollPress.bind.info.args.all[0], [app], 'rollPress.bind() unexpected arguments');
+      assert.compare(app.toggleMenu.bind.info.called, 1, 'toggleMenu.bind() not called');
+      assert.compareArgs(app.toggleMenu.bind.info.args.all[0], [app], 'toggleMenu.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.called, 3, 'context.attach() not called thrice');
+      assert.compareArgs(app.context.attach.info.args.all[0], ['clrBtn',  'click', 'app.clearDisplay.bind()'], 'context.attach() clrBtn unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[1], ['rollBtn',  'click', 'app.rollPress.bind()'], 'context.attach() rollBtn unexpected arguments');
+      assert.compareArgs(app.context.attach.info.args.all[2], ['toggleMenuBtn',  'click', 'app.toggleMenu.bind()'], 'context.attach() toggleMenuBtn unexpected arguments');
       return true;
     }),
     new UnitTest('addUserSaveButtonListener()', function(app, test) {
       app.context.attach = new Stub();
-      app.userSaveButtonPress = new Stub();
+      app.userSaveButtonPress.bind = new Stub('app.userSaveButtonPress.bind()');
       app.addUserSaveButtonListener();
-      assert(app.userSaveButtonPress.bind.info.called.check(), 'userSaveButtonPress.bind() not called');
-      assert(app.userSaveButtonPress.bind.info.args.check(app), 'userSaveButtonPress.bind() unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.args.check('userSaveButton', 'click', app.userSaveButtonPress.bind(app)), 'context.attach() unexpected arguments');
+      assert.compare(app.userSaveButtonPress.bind.info.called, 1, 'userSaveButtonPress.bind() not called');
+      assert.compareArgs(app.userSaveButtonPress.bind.info.args.all[0], [app], 'userSaveButtonPress.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.called, 1, 'context.attach() not called');
+      assert. compareArgs(app.context.attach.info.args.all[0], ['userSaveButton', 'click', 'app.userSaveButtonPress.bind()'], 'context.attach() unexpected arguments');
       return true;
     }),
     new UnitTest('addSaveItemListeners()', function(app, test) {
       app.context.attach = new Stub();
-      app.saveItemPress = new Stub();
-      app.comingSoon = new Stub();
-      app.deleteSaveItem = new Stub();
+      app.saveItemPress.bind = new Stub('app.saveItemPress.bind()');
+      app.comingSoon.bind = new Stub('app.comingSoon.bind()');
+      app.deleteSaveItem.bind = new Stub('app.deleteSaveItem.bind()');
       var id = 'id';
       var rollArray = ['rollArray'];
       app.addSaveItemListeners('id', rollArray);
-      assert(app.saveItemPress.bind.info.called.check(), 'saveItemPress.bind() not called');
-      assert(app.saveItemPress.bind.info.args.check(app, id, rollArray), 'saveItemPress.bind() unexpected arguments');
-      assert(app.comingSoon.bind.info.called.check(), 'comingSoon.bind() not called');
-      assert(app.comingSoon.bind.info.args.check(app), 'comingSoon.bind() unexpected arguments');
-      assert(app.deleteSaveItem.bind.info.called.check(), 'deleteSaveItem.bind() not called');
-      assert(app.deleteSaveItem.bind.info.args.check(app, id), 'deleteSaveItem.bind() unexpected arguments');
-      assert(app.context.attach.info.called.check(), 'context.attach() not called');
-      assert(app.context.attach.info.called.check(3), 'context.attach() not called 3 times');
-      assert(app.context.attach.info.args.all.check(0, id, 'click', app.saveItemPress.bind(app, id, rollArray)), 'context.attach() saveItemPress unexpected args');
-      assert(app.context.attach.info.args.all.check(1, 'mod_' + id, 'click', app.comingSoon.bind(app)), 'context.attach() mod_id unexpected args');
-      assert(app.context.attach.info.args.all.check(2, 'delete_' + id, 'click', app.deleteSaveItem.bind(app, id)), 'context.attach() delete_id unexpected args');
+      assert.compare(app.saveItemPress.bind.info.called, 1, 'saveItemPress.bind() not called');
+      assert.compareArgs(app.saveItemPress.bind.info.args.all[0], [app, id, rollArray], 'saveItemPress.bind() unexpected arguments');
+      assert.compare(app.comingSoon.bind.info.called, 1, 'comingSoon.bind() not called');
+      assert.compareArgs(app.comingSoon.bind.info.args.all[0], [app], 'comingSoon.bind() unexpected arguments');
+      assert.compare(app.deleteSaveItem.bind.info.called, 1, 'deleteSaveItem.bind() not called');
+      assert.compareArgs(app.deleteSaveItem.bind.info.args.all[0], [app, id], 'deleteSaveItem.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.called, 3, 'context.attach() not called 3 times');
+      assert.compareArgs(app.context.attach.info.args.all[0], [id, 'click', 'app.saveItemPress.bind()'], 'context.attach() saveItemPress unexpected args');
+      assert.compareArgs(app.context.attach.info.args.all[1], ['mod_' + id, 'click', 'app.comingSoon.bind()'], 'context.attach() mod_id unexpected args');
+      assert.compareArgs(app.context.attach.info.args.all[2], ['delete_' + id, 'click', 'app.deleteSaveItem.bind()'], 'context.attach() delete_id unexpected args');
       return true;
     }),
   ];


### PR DESCRIPTION
completed unit tests for all addListener type methods.
turned stub() into a constructor and added Stub.bind(), so that bound arguments can be tested as well.
fixed minor bugs throughout.