### PR TITLE
refactored Stub()

### DIFF
--- a/diceRoll/diceRollUnitTests.js
+++ b/diceRoll/diceRollUnitTests.js
@@ -66,22 +66,17 @@ var assert = {
   },
 }
 
-function Stub(output) {
+function Stub(forcedOutput) {
   var info = {
-    output: output,
-    called: 0,
-    args: {
-      all: [],
-      log: function(current) {
-        info.args.all[info.called] = current;
-      },
-    },
+    forcedOutput: forcedOutput,
+    calls: [],
   }
-
   var functionStub = function() {
-    info.args.log(arguments);
-    info.called++;
-    return info.output;
+    info.calls.push({
+      forcedOutput: info.forcedOutput,
+      args: arguments,
+    });
+    return info.forcedOutput;
   }
   functionStub.info = info;
   return functionStub;
@@ -98,13 +93,13 @@ function testList() {
       app.toggleMenu = new Stub();
       app.userSaveButtonCheckDisplay = new Stub();
       app.run();
-      assert.compare(app.addRollBarListeners.info.called, 1, 'addRollBarListeners() not called');
-      assert.compare(app.addCalculatorListeners.info.called, 1, 'addCalculatorListeners() not called');
-      assert.compare(app.addUserSaveButtonListener.info.called, 1, 'addUserSaveButtonListener() not called');
-      assert.compare(app.simulateFirstVisit.info.called, 1, 'simulateFirstVisit() not called');
-      assert.compare(app.checkMemory.info.called, 1, 'checkMemory() not called');
-      assert.compare(app.toggleMenu.info.called, 1, 'toggleMenu() not called');
-      assert.compare(app.userSaveButtonCheckDisplay.info.called, 1, 'userSaveButtonCheckDisplay() not called');
+      assert.compare(app.addRollBarListeners.info.calls.length, 1, 'addRollBarListeners() not called');
+      assert.compare(app.addCalculatorListeners.info.calls.length, 1, 'addCalculatorListeners() not called');
+      assert.compare(app.addUserSaveButtonListener.info.calls.length, 1, 'addUserSaveButtonListener() not called');
+      assert.compare(app.simulateFirstVisit.info.calls.length, 1, 'simulateFirstVisit() not called');
+      assert.compare(app.checkMemory.info.calls.length, 1, 'checkMemory() not called');
+      assert.compare(app.toggleMenu.info.calls.length, 1, 'toggleMenu() not called');
+      assert.compare(app.userSaveButtonCheckDisplay.info.calls.length, 1, 'userSaveButtonCheckDisplay() not called');
       return true;
     }),
     new UnitTest('addCalculatorListeners()', function(app, test) {
@@ -112,73 +107,73 @@ function testList() {
       app.addDiceKeyListeners = new Stub();
       app.addOperatorKeyListeners = new Stub();
       app.addCalculatorListeners();
-      assert.compare(app.addNumberKeyListeners.info.called, 1, 'addNumberKeyListeners() not called');
-      assert.compare(app.addDiceKeyListeners.info.called, 1, 'addDiceKeyListeners() not called');
-      assert.compare(app.addOperatorKeyListeners.info.called, 1, 'addOperatorKeyListeners() not called');
+      assert.compare(app.addNumberKeyListeners.info.calls.length, 1, 'addNumberKeyListeners() not called');
+      assert.compare(app.addDiceKeyListeners.info.calls.length, 1, 'addDiceKeyListeners() not called');
+      assert.compare(app.addOperatorKeyListeners.info.calls.length, 1, 'addOperatorKeyListeners() not called');
       return true;
     }),
     new UnitTest('addNumberKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addNumberKeyListeners();
-      assert.compare(app.keypadPress.bind.info.called, 10, 'keypadPress.bind() not called 10 times');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, 0], 'keypadPress.bind() num0 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, 1], 'keypadPress.bind() num1 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[2], [app, 2], 'keypadPress.bind() num2 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[3], [app, 3], 'keypadPress.bind() num3 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[4], [app, 4], 'keypadPress.bind() num4 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[5], [app, 5], 'keypadPress.bind() num5 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[6], [app, 6], 'keypadPress.bind() num6 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[7], [app, 7], 'keypadPress.bind() num7 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[8], [app, 8], 'keypadPress.bind() num8 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[9], [app, 9], 'keypadPress.bind() num9 unexpected arguments');
-      assert.compare(app.context.attach.info.called, 10, 'context.attach() not called 10 times');
-      assert.compareArgs(app.context.attach.info.args.all[0], ['num0', 'click', 'app.keypadPress.bind()'], 'context.attach() num0 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[1], ['num1', 'click', 'app.keypadPress.bind()'], 'context.attach() num1 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[2], ['num2', 'click', 'app.keypadPress.bind()'], 'context.attach() num2 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[3], ['num3', 'click', 'app.keypadPress.bind()'], 'context.attach() num3 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[4], ['num4', 'click', 'app.keypadPress.bind()'], 'context.attach() num4 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[5], ['num5', 'click', 'app.keypadPress.bind()'], 'context.attach() num5 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[6], ['num6', 'click', 'app.keypadPress.bind()'], 'context.attach() num6 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[7], ['num7', 'click', 'app.keypadPress.bind()'], 'context.attach() num7 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[8], ['num8', 'click', 'app.keypadPress.bind()'], 'context.attach() num8 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[9], ['num9', 'click', 'app.keypadPress.bind()'], 'context.attach() num9 unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.calls.length, 10, 'keypadPress.bind() not called 10 times');
+      assert.compareArgs(app.keypadPress.bind.info.calls[0].args, [app, 0], 'keypadPress.bind() num0 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[1].args, [app, 1], 'keypadPress.bind() num1 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[2].args, [app, 2], 'keypadPress.bind() num2 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[3].args, [app, 3], 'keypadPress.bind() num3 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[4].args, [app, 4], 'keypadPress.bind() num4 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[5].args, [app, 5], 'keypadPress.bind() num5 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[6].args, [app, 6], 'keypadPress.bind() num6 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[7].args, [app, 7], 'keypadPress.bind() num7 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[8].args, [app, 8], 'keypadPress.bind() num8 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[9].args, [app, 9], 'keypadPress.bind() num9 unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 10, 'context.attach() not called 10 times');
+      assert.compareArgs(app.context.attach.info.calls[0].args, ['num0', 'click', 'app.keypadPress.bind()'], 'context.attach() num0 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[1].args, ['num1', 'click', 'app.keypadPress.bind()'], 'context.attach() num1 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[2].args, ['num2', 'click', 'app.keypadPress.bind()'], 'context.attach() num2 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[3].args, ['num3', 'click', 'app.keypadPress.bind()'], 'context.attach() num3 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[4].args, ['num4', 'click', 'app.keypadPress.bind()'], 'context.attach() num4 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[5].args, ['num5', 'click', 'app.keypadPress.bind()'], 'context.attach() num5 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[6].args, ['num6', 'click', 'app.keypadPress.bind()'], 'context.attach() num6 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[7].args, ['num7', 'click', 'app.keypadPress.bind()'], 'context.attach() num7 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[8].args, ['num8', 'click', 'app.keypadPress.bind()'], 'context.attach() num8 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[9].args, ['num9', 'click', 'app.keypadPress.bind()'], 'context.attach() num9 unexpected arguments');
       return true;
     }),
     new UnitTest('addDiceKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addDiceKeyListeners();
-      assert.compare(app.keypadPress.bind.info.called, 8, 'keypadPress.bind() not called 8 times');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, 'd100'], 'keypadPress.bind() d100 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, 'd20'], 'keypadPress.bind() d20 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[2], [app, 'd12'], 'keypadPress.bind() d12 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[3], [app, 'd10'], 'keypadPress.bind() d10 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[4], [app, 'd8'], 'keypadPress.bind() d8 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[5], [app, 'd6'], 'keypadPress.bind() d6 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[6], [app, 'd4'], 'keypadPress.bind() d4 unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[7], [app, 'd2'], 'keypadPress.bind() d2 unexpected arguments');
-      assert.compare(app.context.attach.info.called, 8, 'context.attach() not called 8 times');
-      assert.compareArgs(app.context.attach.info.args.all[0], ['d100', 'click', 'app.keypadPress.bind()'], 'context.attach() d100 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[1], ['d20', 'click', 'app.keypadPress.bind()'], 'context.attach() d20 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[2], ['d12', 'click', 'app.keypadPress.bind()'], 'context.attach() d12 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[3], ['d10', 'click', 'app.keypadPress.bind()'], 'context.attach() d10 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[4], ['d8', 'click', 'app.keypadPress.bind()'], 'context.attach() d8 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[5], ['d6', 'click', 'app.keypadPress.bind()'], 'context.attach() d6 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[6], ['d4', 'click', 'app.keypadPress.bind()'], 'context.attach() d4 unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[7], ['d2', 'click', 'app.keypadPress.bind()'], 'context.attach() d2 unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.calls.length, 8, 'keypadPress.bind() not called 8 times');
+      assert.compareArgs(app.keypadPress.bind.info.calls[0].args, [app, 'd100'], 'keypadPress.bind() d100 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[1].args, [app, 'd20'], 'keypadPress.bind() d20 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[2].args, [app, 'd12'], 'keypadPress.bind() d12 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[3].args, [app, 'd10'], 'keypadPress.bind() d10 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[4].args, [app, 'd8'], 'keypadPress.bind() d8 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[5].args, [app, 'd6'], 'keypadPress.bind() d6 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[6].args, [app, 'd4'], 'keypadPress.bind() d4 unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[7].args, [app, 'd2'], 'keypadPress.bind() d2 unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 8, 'context.attach() not called 8 times');
+      assert.compareArgs(app.context.attach.info.calls[0].args, ['d100', 'click', 'app.keypadPress.bind()'], 'context.attach() d100 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[1].args, ['d20', 'click', 'app.keypadPress.bind()'], 'context.attach() d20 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[2].args, ['d12', 'click', 'app.keypadPress.bind()'], 'context.attach() d12 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[3].args, ['d10', 'click', 'app.keypadPress.bind()'], 'context.attach() d10 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[4].args, ['d8', 'click', 'app.keypadPress.bind()'], 'context.attach() d8 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[5].args, ['d6', 'click', 'app.keypadPress.bind()'], 'context.attach() d6 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[6].args, ['d4', 'click', 'app.keypadPress.bind()'], 'context.attach() d4 unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[7].args, ['d2', 'click', 'app.keypadPress.bind()'], 'context.attach() d2 unexpected arguments');
       return true;
     }),
     new UnitTest('addOperatorKeyListeners()', function(app, test) {
       app.context.attach = new Stub();
       app.keypadPress.bind = new Stub('app.keypadPress.bind()');
       app.addOperatorKeyListeners();
-      assert.compare(app.keypadPress.bind.info.called, 2, 'keypadPress.bind() not called twice');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[0], [app, '+'], 'keypadPress.bind() num+ unexpected arguments');
-      assert.compareArgs(app.keypadPress.bind.info.args.all[1], [app, '-'], 'keypadPress.bind() num- unexpected arguments');
-      assert.compare(app.context.attach.info.called, 2, 'context.attach() not called twice');
-      assert.compareArgs(app.context.attach.info.args.all[0], ['num+', 'click', 'app.keypadPress.bind()'], 'context.attach() num+ unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[1], ['num-', 'click', 'app.keypadPress.bind()'], 'context.attach() num- unexpected arguments');
+      assert.compare(app.keypadPress.bind.info.calls.length, 2, 'keypadPress.bind() not called twice');
+      assert.compareArgs(app.keypadPress.bind.info.calls[0].args, [app, '+'], 'keypadPress.bind() num+ unexpected arguments');
+      assert.compareArgs(app.keypadPress.bind.info.calls[1].args, [app, '-'], 'keypadPress.bind() num- unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 2, 'context.attach() not called twice');
+      assert.compareArgs(app.context.attach.info.calls[0].args, ['num+', 'click', 'app.keypadPress.bind()'], 'context.attach() num+ unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[1].args, ['num-', 'click', 'app.keypadPress.bind()'], 'context.attach() num- unexpected arguments');
       return true;
     }),
     new UnitTest('addRollBarListeners()', function(app, test) {
@@ -187,26 +182,26 @@ function testList() {
       app.rollPress.bind = new Stub('app.rollPress.bind()');
       app.toggleMenu.bind = new Stub('app.toggleMenu.bind()');
       app.addRollBarListeners();
-      assert.compare(app.clearDisplay.bind.info.called, 1, 'clearDisplay.bind() not called');
-      assert.compareArgs(app.clearDisplay.bind.info.args.all[0], [app], 'clearDisplay.bind() unexpected arguments');
-      assert.compare(app.rollPress.bind.info.called, 1, 'rollPress.bind() not called');
-      assert.compareArgs(app.rollPress.bind.info.args.all[0], [app], 'rollPress.bind() unexpected arguments');
-      assert.compare(app.toggleMenu.bind.info.called, 1, 'toggleMenu.bind() not called');
-      assert.compareArgs(app.toggleMenu.bind.info.args.all[0], [app], 'toggleMenu.bind() unexpected arguments');
-      assert.compare(app.context.attach.info.called, 3, 'context.attach() not called thrice');
-      assert.compareArgs(app.context.attach.info.args.all[0], ['clrBtn',  'click', 'app.clearDisplay.bind()'], 'context.attach() clrBtn unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[1], ['rollBtn',  'click', 'app.rollPress.bind()'], 'context.attach() rollBtn unexpected arguments');
-      assert.compareArgs(app.context.attach.info.args.all[2], ['toggleMenuBtn',  'click', 'app.toggleMenu.bind()'], 'context.attach() toggleMenuBtn unexpected arguments');
+      assert.compare(app.clearDisplay.bind.info.calls.length, 1, 'clearDisplay.bind() not called');
+      assert.compareArgs(app.clearDisplay.bind.info.calls[0].args, [app], 'clearDisplay.bind() unexpected arguments');
+      assert.compare(app.rollPress.bind.info.calls.length, 1, 'rollPress.bind() not called');
+      assert.compareArgs(app.rollPress.bind.info.calls[0].args, [app], 'rollPress.bind() unexpected arguments');
+      assert.compare(app.toggleMenu.bind.info.calls.length, 1, 'toggleMenu.bind() not called');
+      assert.compareArgs(app.toggleMenu.bind.info.calls[0].args, [app], 'toggleMenu.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 3, 'context.attach() not called thrice');
+      assert.compareArgs(app.context.attach.info.calls[0].args, ['clrBtn',  'click', 'app.clearDisplay.bind()'], 'context.attach() clrBtn unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[1].args, ['rollBtn',  'click', 'app.rollPress.bind()'], 'context.attach() rollBtn unexpected arguments');
+      assert.compareArgs(app.context.attach.info.calls[2].args, ['toggleMenuBtn',  'click', 'app.toggleMenu.bind()'], 'context.attach() toggleMenuBtn unexpected arguments');
       return true;
     }),
     new UnitTest('addUserSaveButtonListener()', function(app, test) {
       app.context.attach = new Stub();
       app.userSaveButtonPress.bind = new Stub('app.userSaveButtonPress.bind()');
       app.addUserSaveButtonListener();
-      assert.compare(app.userSaveButtonPress.bind.info.called, 1, 'userSaveButtonPress.bind() not called');
-      assert.compareArgs(app.userSaveButtonPress.bind.info.args.all[0], [app], 'userSaveButtonPress.bind() unexpected arguments');
-      assert.compare(app.context.attach.info.called, 1, 'context.attach() not called');
-      assert. compareArgs(app.context.attach.info.args.all[0], ['userSaveButton', 'click', 'app.userSaveButtonPress.bind()'], 'context.attach() unexpected arguments');
+      assert.compare(app.userSaveButtonPress.bind.info.calls.length, 1, 'userSaveButtonPress.bind() not called');
+      assert.compareArgs(app.userSaveButtonPress.bind.info.calls[0].args, [app], 'userSaveButtonPress.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 1, 'context.attach() not called');
+      assert. compareArgs(app.context.attach.info.calls[0].args, ['userSaveButton', 'click', 'app.userSaveButtonPress.bind()'], 'context.attach() unexpected arguments');
       return true;
     }),
     new UnitTest('addSaveItemListeners()', function(app, test) {
@@ -217,16 +212,16 @@ function testList() {
       var id = 'id';
       var rollArray = ['rollArray'];
       app.addSaveItemListeners('id', rollArray);
-      assert.compare(app.saveItemPress.bind.info.called, 1, 'saveItemPress.bind() not called');
-      assert.compareArgs(app.saveItemPress.bind.info.args.all[0], [app, id, rollArray], 'saveItemPress.bind() unexpected arguments');
-      assert.compare(app.comingSoon.bind.info.called, 1, 'comingSoon.bind() not called');
-      assert.compareArgs(app.comingSoon.bind.info.args.all[0], [app], 'comingSoon.bind() unexpected arguments');
-      assert.compare(app.deleteSaveItem.bind.info.called, 1, 'deleteSaveItem.bind() not called');
-      assert.compareArgs(app.deleteSaveItem.bind.info.args.all[0], [app, id], 'deleteSaveItem.bind() unexpected arguments');
-      assert.compare(app.context.attach.info.called, 3, 'context.attach() not called 3 times');
-      assert.compareArgs(app.context.attach.info.args.all[0], [id, 'click', 'app.saveItemPress.bind()'], 'context.attach() saveItemPress unexpected args');
-      assert.compareArgs(app.context.attach.info.args.all[1], ['mod_' + id, 'click', 'app.comingSoon.bind()'], 'context.attach() mod_id unexpected args');
-      assert.compareArgs(app.context.attach.info.args.all[2], ['delete_' + id, 'click', 'app.deleteSaveItem.bind()'], 'context.attach() delete_id unexpected args');
+      assert.compare(app.saveItemPress.bind.info.calls.length, 1, 'saveItemPress.bind() not called');
+      assert.compareArgs(app.saveItemPress.bind.info.calls[0].args, [app, id, rollArray], 'saveItemPress.bind() unexpected arguments');
+      assert.compare(app.comingSoon.bind.info.calls.length, 1, 'comingSoon.bind() not called');
+      assert.compareArgs(app.comingSoon.bind.info.calls[0].args, [app], 'comingSoon.bind() unexpected arguments');
+      assert.compare(app.deleteSaveItem.bind.info.calls.length, 1, 'deleteSaveItem.bind() not called');
+      assert.compareArgs(app.deleteSaveItem.bind.info.calls[0].args, [app, id], 'deleteSaveItem.bind() unexpected arguments');
+      assert.compare(app.context.attach.info.calls.length, 3, 'context.attach() not called 3 times');
+      assert.compareArgs(app.context.attach.info.calls[0].args, [id, 'click', 'app.saveItemPress.bind()'], 'context.attach() saveItemPress unexpected args');
+      assert.compareArgs(app.context.attach.info.calls[1].args, ['mod_' + id, 'click', 'app.comingSoon.bind()'], 'context.attach() mod_id unexpected args');
+      assert.compareArgs(app.context.attach.info.calls[2].args, ['delete_' + id, 'click', 'app.deleteSaveItem.bind()'], 'context.attach() delete_id unexpected args');
       return true;
     }),
   ];


### PR DESCRIPTION
refactored Stub()
- removed counters, and instead rely on the length of info.calls.length to know the number of calls
- functionStub() now pushes an object to info.calls and returns forcedOutput
- the functionStub() parameter `output` is now called `forcedOutput` to better reflect its behavior